### PR TITLE
(maint) Move install to Beaker-Puppet_install_helper usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',    :require => false
+  gem 'beaker-puppet_install_helper', :require => false
 end
 
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,31 +1,13 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
 
 RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
 end
 
-FUTURE_PARSER = ENV['FUTURE_PARSER'] == 'true' || false
-
-unless ENV['BEAKER_provision'] == 'no'
-  is_foss = (ENV['IS_PE'] == 'no' || ENV['IS_PE'] == 'false') ? true : false
-  if hosts.first.is_pe? && !is_foss
-    install_pe
-  else
-    version = ENV['PUPPET_VERSION'] || '3.8.1'
-    download_url = ENV['WIN_DOWNLOAD_URL'] || 'http://downloads.puppetlabs.com/windows/'
-    hosts.each do |host|
-      if host['platform'] =~ /windows/i
-        install_puppet_from_msi(host,
-                                {
-                                  :win_download_url => download_url,
-                                  :version => version,
-                                  :install_32 => ENV['CLIENT_32'] == 'true'})
-      end
-    end
-  end
-
-end
 unless ENV['MODULE_provision'] == 'no'
   puts "Install wsus_client module to agent #{default.node_name}"
   result = on default, "echo #{default['distmoduledir']}"


### PR DESCRIPTION
- Allows us to move puppet install logic to helper gem
  as well as use AIO helpers inside