### PR TITLE
Fixed incorrect example for scheduled hour to a: work and b: make sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class { 'wsus_client':
   server_url             => 'http://myserver:8530',
   auto_update_option     => "Scheduled",
   scheduled_install_day  => 2, #Patch Tuesdays 
-  scheduled_install_time => 2, # 4AM
+  scheduled_install_hour => 2, # 2AM
 }
 ```
 


### PR DESCRIPTION
The variable was renamed to scheduled_install_hour at some point, the README wasn't. 