### PR TITLE
(MODULES-2180) Fix the max value of RebootRelaunchTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class {'wsus_client':
 * `elevate_non_admins`: *Optional.* Whether to elevate non-admins when attempting to update. Valid options: 'true', 'false' and 'undef'. Default: 'undef'
 * `no_auto_reboot_with_logged_on_users`: *Optional.* Disables reboot when a user is logged in to the system. Valid options: 'true', 'false' and 'undef'. Default: 'undef'
 * `no_auto_update`: *Optional.* Disable Auto Update. Valid options: 'true', 'false' and 'undef'. Default: 'undef'
-* `reboot_relaunch_timeout_minutes`: *Optional.* How long to wait before reboot will be attempted again. Valid values are 1 through 440. Default: 'undef'
+* `reboot_relaunch_timeout_minutes`: *Optional.* How long to wait before reboot will be attempted again. Valid values are 1 through 1440. Default: 'undef'
 * `reboot_warning_timeout_minutes`: *Optional.* How long to give the user to respond before rebooting the system. Valid values are 1 through 30. Default: 'undef'
 * `reschedule_wait_time_minutes`: *Optional.* How long to reschedule between attempts to update. Valid values are 1 through 60. Default: 'undef'
 * `scheduled_install_day`: *Optional.* Day of the week to install updates on. Valid values are Everyday, Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday. Default: 'undef'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,7 +133,7 @@ class wsus_client (
 
   wsus_client::setting{ "${_au_base}\\RebootRelaunchTimeout":
     data           => $reboot_relaunch_timeout_minutes,
-    validate_range => [1,440],
+    validate_range => [1,1440],
   }
 
   wsus_client::setting{ "${_au_base}\\RebootWarningTimeout":

--- a/spec/acceptance/wsus_client_spec.rb
+++ b/spec/acceptance/wsus_client_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'wsus_client' do
     it_behaves_like 'enabled range',
                     :reboot_relaunch_timeout_minutes,
                     'RebootRelaunchTimeout',
-                    [1, 440],
+                    [1, 1440],
                     au_key
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -295,12 +295,12 @@ describe 'wsus_client' do
       context 'reboot_relaunch_timeout_minutes =>' do
         let(:reg_key) { "#{au_key}\\RebootRelaunchTimeout" }
         let(:below_range) { 0 }
-        let(:above_range) { 441 }
+        let(:above_range) { 1441 }
         let(:param_sym) { :reboot_relaunch_timeout_minutes }
-        it_behaves_like 'valid range', [1, 220, 440]
+        it_behaves_like 'valid range', [1, 720, 1440]
         it_behaves_like 'below range'
         it_behaves_like 'above range'
-        it_behaves_like 'enabled feature', 200
+        it_behaves_like 'enabled feature', 720
       end
 
       context 'reboot_warning_timeout_minutes =>' do


### PR DESCRIPTION
The max value of RebootRelaunchTimeout should be 1440(24 hours), rather than 440. I guess this miss is due to the numerical separator used in the [official document](https://technet.microsoft.com/en-us/library/dd939844%28v=ws.10%29.aspx). 

```
Range = n, where n = time in minutes (1–1,440). 
```