### PR TITLE
(FM-2337) Release 1.0.0 - First supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
+##2015-09-01 - Supported release 1.0.0
+
+###Summary
+
+First supported release
+
+###Features
+- Add metadata for Puppet 4 and PE 2015.2.0
+- Update documentation
+
 ##2015-07-02 - Unsupported release 0.1.3
 
 ###Summary
 
 Fix the max value of RebootRelaunchTimeout
 
-####Features
+###Features
 - Increase RebootRelaunchTimeout to 1440 instead of 440
 
 ##2015-06-25 - Unsupported release 0.1.2

--- a/metadata.json
+++ b/metadata.json
@@ -23,11 +23,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.7.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 2015.3.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This also adds metadata for Puppet 2015.2 and Puppet 4.x.