### PR TITLE
(FM-4919) update modulesync / Restrict Rake ~> 10.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 pkg/
 Gemfile.lock
 Gemfile.local
-vendor/
 spec/fixtures/
 log/
 junit/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,5 @@ matrix:
     env: PUPPET_GEM_VERSION="3.7.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="3.7.0"
-  allow_failures:
-    - rvm: 2.1.5
-      env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 #end
 
 group :development do
-  gem 'rake',                                :require => false
+  gem 'rake', '~>10.1',                      :require => false
   gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -25,13 +25,24 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
+# The following gems are not included by default as they require DevKit on Windows.
+# You should probably include them in a Gemfile.local or a ~/.gemfile
+#gem 'pry' #this may already be included in the gemfile
+#gem 'pry-stack_explorer', :require => false
+#if RUBY_VERSION =~ /^2/
+#  gem 'pry-byebug'
+#else
+#  gem 'pry-debugger'
+#end
+
 group :development do
   gem 'rake',                                :require => false
-  gem 'rspec', '~>3.0.0',                    :require => false
+  gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
+  gem 'pry',                                 :require => false
 end
 
 group :system_tests do
@@ -108,8 +119,14 @@ if explicitly_require_windows_gems
   gem "windows-pr",  "1.2.3",           :require => false
 end
 
+# Evaluate Gemfile.local if it exists
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
 end
 
 # vim:ft=ruby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ matrix:
   fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
-- gem install bundler --quiet --no-ri --no-rdoc
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off


### PR DESCRIPTION
Beaker needs a version of Rake less than
11 due to using `last_comment' in
rake_task.rb:62. Reduce the version of Rake
down to the same dependency that Beaker does
as a development dependency.

Paired with Glenn Sarti <glenn.sarti at puppetlabs dot com>