### PR TITLE
(MODULES-3240) Fix rspec-puppet incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,6 @@ group :development do
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
   gem 'pry',                                 :require => false
-  # rspec-puppet should be pinned to 2.3.2 until MODULES-3240 is resolved
-  gem 'rspec-puppet','2.3.2',                :require => false
 end
 
 group :system_tests do

--- a/spec/functions/parse_auto_update_option_spec.rb
+++ b/spec/functions/parse_auto_update_option_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'parse_auto_update_option' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   expected_hash = {'NotifyOnly' => 2,
                    'AutoNotify' => 3,
                    'Scheduled' => 4,

--- a/spec/functions/parse_scheduled_install_day_spec.rb
+++ b/spec/functions/parse_scheduled_install_day_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'parse_scheduled_install_day' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   expect_day = {'Everyday' => 0,
                 'Sunday' => 1,
                 'Monday' => 2,


### PR DESCRIPTION
Revert the explicit version pin of the rspec-puppet gem.

Removed creating the 'scope' variable as it is already available via rspec-puppet.  Without removing this statement, unit tests will fail on rspec-puppet 2.4.0, and probably subsequent versions as well.