### PR TITLE
(MODULES-3016) Support AlwaysAutoRebootAtScheduledTime

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class wsus_client (
   $reschedule_wait_time_minutes        = undef,
   $scheduled_install_day               = undef,
   $scheduled_install_hour              = undef,
+  $always_auto_reboot_at_scheduled_time = undef,
   $target_group                        = undef,
   $purge_values                        = false,
 ){
@@ -168,5 +169,11 @@ class wsus_client (
   wsus_client::setting{ "${_basekey}\\TargetGroup":
     type => 'string',
     data => $target_group,
+  }
+
+  wsus_client::setting{ "${_au_base}\\AlwaysAutoRebootAtScheduledTime":
+    data          => $always_auto_reboot_at_scheduled_time,
+    has_enabled   => false,
+    validate_bool => true,
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -357,6 +357,13 @@ describe 'wsus_client' do
         let(:param_sym) { :target_group }
         it_behaves_like 'enabled feature', 'UberUserGroup'
       end
+
+      context 'always_auto_reboot_at_scheduled_time =>' do
+        let(:reg_key) { "#{au_key}\\AlwaysAutoRebootAtScheduledTime" }
+        let(:param_sym) { :always_auto_reboot_at_scheduled_time }
+        it_behaves_like 'bool value'
+        it_behaves_like 'non enabled feature'
+      end
     end
   end
 end


### PR DESCRIPTION
The AlwaysAutoRebootAtScheduledTime key allows the user to ensure
that any updates are applied on the schedule set by the user and
that the computer will restart regardless if a user is logged on
or not