### PR TITLE
(MODULES-3475) Support AlwaysAutoRebootAtScheduledTimeMinutes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,22 +1,23 @@
 class wsus_client (
-  $server_url                          = undef,
-  $enable_status_server                = undef,
-  $accept_trusted_publisher_certs      = undef,
-  $auto_update_option                  = undef, #2..5 valid values
-  $auto_install_minor_updates          = undef,
-  $detection_frequency_hours           = undef,
-  $disable_windows_update_access       = undef,
-  $elevate_non_admins                  = undef,
-  $no_auto_reboot_with_logged_on_users = undef,
-  $no_auto_update                      = undef,
-  $reboot_relaunch_timeout_minutes     = undef,
-  $reboot_warning_timeout_minutes      = undef,
-  $reschedule_wait_time_minutes        = undef,
-  $scheduled_install_day               = undef,
-  $scheduled_install_hour              = undef,
-  $always_auto_reboot_at_scheduled_time = undef,
-  $target_group                        = undef,
-  $purge_values                        = false,
+  $server_url                                   = undef,
+  $enable_status_server                         = undef,
+  $accept_trusted_publisher_certs               = undef,
+  $auto_update_option                           = undef, #2..5 valid values
+  $auto_install_minor_updates                   = undef,
+  $detection_frequency_hours                    = undef,
+  $disable_windows_update_access                = undef,
+  $elevate_non_admins                           = undef,
+  $no_auto_reboot_with_logged_on_users          = undef,
+  $no_auto_update                               = undef,
+  $reboot_relaunch_timeout_minutes              = undef,
+  $reboot_warning_timeout_minutes               = undef,
+  $reschedule_wait_time_minutes                 = undef,
+  $scheduled_install_day                        = undef,
+  $scheduled_install_hour                       = undef,
+  $always_auto_reboot_at_scheduled_time         = undef,
+  $always_auto_reboot_at_scheduled_time_minutes = undef,
+  $target_group                                 = undef,
+  $purge_values                                 = false,
 ){
 
   $_basekey = $::operatingsystemrelease ? {
@@ -175,5 +176,10 @@ class wsus_client (
     data          => $always_auto_reboot_at_scheduled_time,
     has_enabled   => false,
     validate_bool => true,
+  }
+  wsus_client::setting{ "${_au_base}\\AlwaysAutoRebootAtScheduledTimeMinutes":
+    data           => $always_auto_reboot_at_scheduled_time_minutes,
+    validate_range => [15,180],
+    has_enabled    => false,
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -364,6 +364,17 @@ describe 'wsus_client' do
         it_behaves_like 'bool value'
         it_behaves_like 'non enabled feature'
       end
+
+      context 'always_auto_reboot_at_scheduled_time_minutes =>' do
+        let(:reg_key) { "#{au_key}\\AlwaysAutoRebootAtScheduledTimeMinutes" }
+        let(:param_sym) { :always_auto_reboot_at_scheduled_time_minutes }
+        let(:below_range) { 14 }
+        let(:above_range) { 181 }
+        it_behaves_like 'valid range', [15, 83, 180]
+        it_behaves_like 'below range'
+        it_behaves_like 'above range'
+        it_behaves_like 'non enabled feature'
+      end
     end
   end
 end


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-3475

adding support for AlwaysAutoRebootAtScheduledTimeMinutes which allows to restart host immediately after installing the updates