### PR TITLE
MODULES/2420-Make wuauserv service be idempotent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,9 +39,16 @@ class wsus_client (
     purge_values => $purge_values
   }
 
-  service{ 'wuauserv':
-    ensure => running,
-    enable => true,
+  case $::kernelmajversion {
+    '6.3', '10.0' : {
+      service { 'wuauserv': enable => true, }
+    }
+    default       : {
+      service { 'wuauserv':
+        ensure => running,
+        enable => true,
+      }
+    }
   }
 
   Registry_value{ require => Registry_key[$_basekey], notify => Service['wuauserv'] }


### PR DESCRIPTION
Do not manage wuauserv service status if Windows Server 2012, Windows 8.1, Windows Server 2016 Technical Preview or Windows 10