### PR TITLE
(maint) Pin specinfra gem to 2.59.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ coverage/
 .*.sw[op]
 .DS_Store
 .rspec
+tmp/
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,13 @@
       env: PUPPET_GEM_VERSION="3.7.0"
 Gemfile:
   supports_windows: true
+  optional:
+    ':system_tests':
+      # There is a known problem with specinfra versions above 2.59.0
+      # https://github.com/mizzy/specinfra/pull/561
+      # Until this is resolved, pin specinfra to 2.59.0
+      - gem: specinfra
+        version: '=2.59.0'
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :system_tests do
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'beaker-puppet_install_helper',  :require => false
+  gem 'specinfra', '=2.59.0',          :require => false
 end
 
 # The recommendation is for PROJECT_GEM_VERSION, although there are older ways

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,12 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+
+# These lint exclusions are in puppetlabs_spec_helper but needs a version above 0.10.3 
+# Line length test is 80 chars in puppet-lint 1.1.0
 PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+# Line length test is 140 chars in puppet-lint 2.x
+PuppetLint.configuration.send('disable_140chars')
 
 desc "Validate manifests, templates, and ruby files"
 task :validate do


### PR DESCRIPTION
There is a known problem with specinfra versions above 2.59.0 which causes
CI failures.
https://github.com/mizzy/specinfra/pull/561
This commit pins specinfra to 2.59.0 until this is resolved

The rakefile is attempting to override the default puppet lint settings however
these settings are more permissive than the defaults and are causing false
lint failures e.g. the vendor directory is not excluded in thie Rakefile but
the puppetlabs_spec_helper does this by default.  This PR removes the
ignore_paths setting as the spec helper already does this.  Also added a comment
that the 80 and 140 char rule changes can be removed once next version of
spec_helper is released as they are already the defaults.