### PR TITLE
(maint) Fix shared group test 'below range'

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -48,7 +48,7 @@ describe 'wsus_client' do
 
   shared_examples 'below range' do
     let(:params) { {param_sym => below_range} }
-    let(:error_message) { /Expected #{below_range} to be greater or equal to \d, got #{below_range}/ }
+    let(:error_message) { /Expected #{below_range} to be greater or equal to \d+, got #{below_range}/ }
     it {
       expect { catalogue }.to raise_error(Puppet::Error, error_message)
     }


### PR DESCRIPTION
Previously the verification regular expression expected a single digit as the
lower bound integer.  This is not the case as some settings could contain one
or more digits.  This commit changes the regular expression to expect one or
more digits in the error message.