### PR TITLE
(MODULES-2420) omit ensure => running due to "trigger start"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,6 @@ class wsus_client (
   }
 
   service{ 'wuauserv':
-    ensure => running,
     enable => true,
   }
 


### PR DESCRIPTION
In newer Windows versions wsuaserv supports a start type of "manual (trigger
start)" which is another form of running/enabled in which the service will
start (on-demand) in response to some defined event. However, in the
wsus-client module, puppet sees this state as enabled but not running, and
starts the service with every run.  The short-term fix in this commit is to
consider the service running when enabled on these operating systems. The
long-term fix, captured by PUP-6489 may be to modify the puppet windows service
provider to support the trigger state.  It's unclear at this time whether that
effort would be justified because at this time it seems like trigger start
services are not commonplace and aren't an officially supported service type.

reference
http://mikefrobbins.com/2015/12/24/use-powershell-to-determine-services-with-a-starttype-of-automatic-or-manual-with-trigger-start/

Signed-off-by: Moses Mendoza <mendoza.moses@gmail.com>