### PR TITLE
(maint) changes name in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "puppetlabs/wsus_client",
+  "name": "puppetlabs-wsus_client",
   "version": "1.0.3",
   "author": "Puppet Inc",
   "summary": "Manage WSUS (Windows Server Update Service) settings for client nodes",


### PR DESCRIPTION
to go along with modern convention and to be compatible with blacksmith, the slash needs to be replaced with a hyphen