### PR TITLE
(MODULES-4271) Add Server 2016 and client OS to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,11 @@
         "Server 2008",
         "Server 2008 R2",
         "Server 2012",
-        "Server 2012 R2"
+        "Server 2012 R2",
+        "Server 2016",
+        "7",
+        "8",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
This commit adds Server 2016 and the corresponding Windows Client versions to
the list of supported Windows OSes.
