### PR TITLE
pdksync - Update gha templates

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
       "version_requirement": ">= 5.5.10 < 7.0.0"
     }
   ],
-  "pdk-version": "1.18.1",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g97a63c9"
+  "pdk-version": "1.19.0.pre (47)",
+  "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
+  "template-ref": "heads/main-0-g1862b96"
 }


### PR DESCRIPTION
Update gha templates
pdk version: `1.19.0.pre (47)` 
