### PR TITLE
(gh-cat-9) Add specific data types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,21 +142,21 @@ class wsus_client (
   Optional[Boolean] $accept_trusted_publisher_certs                                                                 = undef,
   Optional[Variant[Enum['NotifyOnly', 'AutoNotify', 'Scheduled', 'AutoInstall'],Integer[2,5]]] $auto_update_option  = undef,
   Optional[Boolean] $auto_install_minor_updates                                                                     = undef,
-  Optional[Integer[1,22]] $detection_frequency_hours                                                                = undef,
+  Optional[Variant[Integer[1,22],Boolean]] $detection_frequency_hours                                               = undef,
   Optional[Boolean] $disable_windows_update_access                                                                  = undef,
   Optional[Boolean] $elevate_non_admins                                                                             = undef,
   Optional[Boolean] $no_auto_reboot_with_logged_on_users                                                            = undef,
   Optional[Boolean] $no_auto_update                                                                                 = undef,
-  Optional[Integer[1,1440]] $reboot_relaunch_timeout_minutes                                                        = undef,
-  Optional[Integer[1,30]] $reboot_warning_timeout_minutes                                                           = undef,
-  Optional[Integer[1,60]] $reschedule_wait_time_minutes                                                             = undef,
+  Optional[Variant[Integer[1,1440],Boolean]] $reboot_relaunch_timeout_minutes                                       = undef,
+  Optional[Variant[Integer[1,30],Boolean]] $reboot_warning_timeout_minutes                                          = undef,
+  Optional[Variant[Integer[1,60],Boolean]] $reschedule_wait_time_minutes                                            = undef,
   Optional[Variant[Enum['Everyday', 'Sunday', 'Monday', 'Tuesday', 'Wednesday','Thursday', 'Friday', 'Saturday'],Integer[0,7]]]
   $scheduled_install_day                                                                                            = undef,
-  Optional[Integer[0,23]] $scheduled_install_hour                                                                   = undef,
+  Optional[Variant[Integer[0,23],Boolean]] $scheduled_install_hour                                                  = undef,
   Optional[Boolean] $always_auto_reboot_at_scheduled_time                                                           = undef,
-  Optional[Integer[15,180]] $always_auto_reboot_at_scheduled_time_minutes                                           = undef,
+  Optional[Variant[Integer[15,180],Boolean]] $always_auto_reboot_at_scheduled_time_minutes                          = undef,
   Boolean $purge_values                                                                                             = false,
-  Optional[String] $target_group                                                                                    = undef,
+  Optional[Variant[String,Boolean]] $target_group                                                                   = undef,
 ) {
   $_basekey = 'HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,20 +8,32 @@
 #    class { 'wsus_client': }
 #
 # @param server_url
-#   Sets the URL at which your WSUS server can be reached. Valid options: fully qualified URL starting with 'http' or 'https', including protocol and port; 'false'; or undef. Default: undef.
+#   Sets the URL at which your WSUS server can be reached. Valid options: fully qualified URL starting with 'http' or 'https', including
+#   protocol and port; 'false'; or undef. Default: undef.
 #   When set to a URL, Puppet sets the WUServer registry key to this parameter's value and the UseWUServer registry key to '1' (true).
-#   If this parameter is set to 'false', Puppet sets UseWUServer to false, disabling WSUS updates on the client. If undefined, Puppet does not manage WUServer or UseWUServer.
-#   Even if HTTPS is required for authentication, you can use 'http' URLs instead of 'https'. WSUS automatically switches to an HTTPS connection when required and increments the provided port by 1. For example, if the server_url is 'http://myserver:8530' and the WSUS server requires HTTPS access, the client automatically uses 'https://myserver:8531' to authenticate, then downloads the updates without encryption via the server_url. This performs better than using SSL to encrypt binary downloads.
-#   Note: The server_url parameter is central to using wsus_client to manage updates from a WSUS server. While not strictly required to use the class, note that you must manage the WUServer and UseWUServer registry keys yourself if you do not set server_url and enable_status_server.
+#   If this parameter is set to 'false', Puppet sets UseWUServer to false, disabling WSUS updates on the client. If undefined, Puppet 
+#   does not manage WUServer or UseWUServer.
+#   Even if HTTPS is required for authentication, you can use 'http' URLs instead of 'https'. WSUS automatically switches to an HTTPS 
+#   connection when required and increments the provided port by 1. For example, if the server_url is 'http://myserver:8530' and the 
+#   WSUS server requires HTTPS access, the client automatically uses 'https://myserver:8531' to authenticate, then downloads the updates 
+#   without encryption via the server_url. This performs better than using SSL to encrypt binary downloads.
+#   Note: The server_url parameter is central to using wsus_client to manage updates from a WSUS server. While not strictly required 
+#   to use the class, note that you must manage the WUServer and UseWUServer registry keys yourself if you do not set server_url 
+#   and enable_status_server.
 #
 # @param enable_status_server
-#   Determines whether Puppet also sets the WUStatusServer registry key, which sets the client status reporting destination. Valid options: 'true', 'false', and undef. Default: undef.
-#   If this parameter is set to true, Puppet sets the value for the WUStatusServer registry key to the server_url parameter's value. Therefore, when setting this parameter to true, you must also set the server_url parameter to a valid URL or your Puppet run will fail with an error.
+#   Determines whether Puppet also sets the WUStatusServer registry key, which sets the client status reporting destination. 
+#   Valid options: 'true', 'false', and undef. Default: undef.
+#   If this parameter is set to true, Puppet sets the value for the WUStatusServer registry key to the server_url parameter's value. 
+#   Therefore, when setting this parameter to true, you must also set the server_url parameter to a valid URL or your Puppet run 
+#   will fail with an error.
 #   If enable_status_server is set to 'false', Puppet removes the WUStatusServer registry key.
-#   Note: Windows requires the same value for WUStatusServer and WUServer, so wsus_client does not provide an option to set a different status server URL.
+#   Note: Windows requires the same value for WUStatusServer and WUServer, so wsus_client does not provide an option to set a 
+#   different status server URL.
 #
 # @param accept_trusted_publisher_certs
-#   Determines whether to accept trusted non-Microsoft publisher certificates when checking for updates. Valid options: 'true', 'false', and undef.
+#   Determines whether to accept trusted non-Microsoft publisher certificates when checking for updates. 
+#   Valid options: 'true', 'false', and undef.
 #   Default: undef.
 #   If 'true', the WSUS server distributes signed non-Microsoft updates.
 #   If 'false', the WSUS server only distributes Microsoft updates.
@@ -49,11 +61,14 @@
 # @param detection_frequency_hours
 #   Sets an interval in hours for clients to check for updates. Valid values: integers 1 through 22.
 #   Default: undef.
-#   If this enabled parameter has a valid value, Puppet sets the DetectionFrequency registry key to its value and the DetectionFrequencyEnabled Boolean registry key to 'true'.
-#   Otherwise, Puppet sets DetectionFrequencyEnabled to 'false' and Windows ignores the value of DetectionFrequency, falling back to the Windows default value of 22 hours.
+#   If this enabled parameter has a valid value, Puppet sets the DetectionFrequency registry key to its value and the 
+#   DetectionFrequencyEnabled Boolean registry key to 'true'.
+#   Otherwise, Puppet sets DetectionFrequencyEnabled to 'false' and Windows ignores the value of DetectionFrequency, falling 
+#   back to the Windows default value of 22 hours.
 #
 # @param disable_windows_update_access
-#   Determines whether non-administrators can access Windows Update. Valid options: 'true' (disable access), 'false' (enable access), and undef.
+#   Determines whether non-administrators can access Windows Update. 
+#   Valid options: 'true' (disable access), 'false' (enable access), and undef.
 #   Default: undef.
 #
 # @param elevate_non_admins
@@ -63,27 +78,42 @@
 #   If 'false', only members of the Administrators group can approve or refuse updates.
 #
 # @param no_auto_reboot_with_logged_on_users
-#   Determines whether to automatically reboot while a user is logged in to the client. Valid options: 'true', 'false', and undef. Default: undef.
-#   If 'true', Windows will not restart the client after installing updates, even if a reboot is required to finish installing the update. If 'false', Windows notifies the user that the client will restart 15 minutes after installing an update that requires a reboot.
+#   Determines whether to automatically reboot while a user is logged in to the client. 
+#   Valid options: 'true', 'false', and undef. Default: undef.
+#   If 'true', Windows will not restart the client after installing updates, even if a reboot is required to finish installing the update. 
+#   If 'false', Windows notifies the user that the client will restart 15 minutes after installing an update that requires a reboot.
 #
 # @param no_auto_update
 #   Disables automatic updates. Valid options: 'true', 'false' (automatic updates enabled), and undef. Default: undef.
 #   Windows disables automatic updates when this parameter is set to 'true' and enables them if it's set to 'false'.
 #
 # @param reboot_relaunch_timeout_minutes
-#  Sets a delay in minutes to wait before attempting to reboot after installing an update that requires one. Valid values: integers 1 through 1440. Default: undef.
-#  If this enabled parameter has a valid value, Puppet sets the RebootRelaunchTimeout registry key to its value and the RebootRelaunchTimeoutEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RebootRelaunchTimeoutEnabled to 'false' and Windows ignores the value of RebootRelaunchTimeout, falling back to the Windows default value of 10 minutes.
+#   Sets a delay in minutes to wait before attempting to reboot after installing an update that requires one.
+#   Valid values: integers 1 through 1440. Default: undef.
+#   If this enabled parameter has a valid value, Puppet sets the RebootRelaunchTimeout registry key to its value and the
+#   RebootRelaunchTimeoutEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RebootRelaunchTimeoutEnabled to 'false' 
+#   and Windows ignores the value of RebootRelaunchTimeout, falling back to the Windows default value of 10 minutes.
 #
 # @param reboot_warning_timeout_minutes
-#   Sets how many minutes users can wait before responding to a prompt to reboot the client after installing an update that requires a reboot. Valid values: integers 1 through 30. Default: undef.
-#   If this enabled parameter has a valid value, Puppet sets the RebootWarningTimeout registry key to its value and the RebootWarningTimeoutEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RebootWarningTimeoutEnabled to 'false' and Windows ignores the value of RebootWarningTimeout, falling back to the Windows default value of 5 minutes.
+#   Sets how many minutes users can wait before responding to a prompt to reboot the client after installing an update that requires
+#   a reboot. Valid values: integers 1 through 30. Default: undef.
+#   If this enabled parameter has a valid value, Puppet sets the RebootWarningTimeout registry key to its value and the
+#   RebootWarningTimeoutEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RebootWarningTimeoutEnabled to 'false' and
+#   Windows ignores the value of RebootWarningTimeout, falling back to the Windows default value of 5 minutes.
 #
 # @param reschedule_wait_time_minutes
-#   Sets how many minutes the client's automatic update service waits at startup before applying updates from a missed scheduled update. Valid values: integers 1 through 60. Default: undef.
-#   This enabled parameter is used only when automatic updates are enabled and auto_update_option is set to 'Scheduled' or '4'. If this parameter is set to a valid value, Puppet sets the RescheduleWaitTime registry key to that value and the RescheduleWaitTimeEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RescheduleWaitTimeEnabled to 'false' and Windows ignores the value of RescheduleWaitTime, falling back to the Windows default behavior of re-attempting installation at the next scheduled update time.
+#   Sets how many minutes the client's automatic update service waits at startup before applying updates from a missed scheduled update.
+#   Valid values: integers 1 through 60. Default: undef.
+#   This enabled parameter is used only when automatic updates are enabled and auto_update_option is set to 'Scheduled' or '4'.
+#   If this parameter is set to a valid value, Puppet sets the RescheduleWaitTime registry key to that value and the
+#   RescheduleWaitTimeEnabled Boolean registry key to 'true'. Otherwise, Puppet sets RescheduleWaitTimeEnabled to 'false' and Windows
+#   ignores the value of RescheduleWaitTime, falling back to the Windows default behavior of re-attempting installation at the next 
+#   scheduled update time.
 #
 # @param scheduled_install_day
-#   Schedules a day of the week to automatically install updates. Valid values: 'Everyday', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', and 'Saturday'. You can also refer to these eight values using the integers 0 through 7, respectively. Default: undef.
+#   Schedules a day of the week to automatically install updates. Valid values: 'Everyday', 'Sunday', 'Monday', 'Tuesday', 'Wednesday',
+#   'Thursday', 'Friday', and 'Saturday'. You can also refer to these eight values using the integers 0 through 7, respectively.
+#   Default: undef.
 #   This parameter depends on a valid scheduled_install_hour value and is required when auto_update_option is set to 'Scheduled' or '4'.
 #
 # @param scheduled_install_hour
@@ -94,77 +124,74 @@
 #   Determines whether to automatically reboot. Valid options: 'true', 'false', and undef. Default: undef.
 #
 # @param always_auto_reboot_at_scheduled_time_minutes
-#    Sets the timer to warning a signed-in user that a restart is going to occur. Valid values: integers 15 through 180. Default: undef.
+#   Sets the timer to warning a signed-in user that a restart is going to occur. Valid values: integers 15 through 180. Default: undef.
 #    When the timer runs out, the restart will proceed even if the PC has signed-in users.
 #
 # @param purge_values
-#   Determines whether Puppet purges values of unmanaged registry keys under the WindowsUpdate parent key. Valid options: Boolean. Default: 'false'.
+#   Determines whether Puppet purges values of unmanaged registry keys under the WindowsUpdate parent key. Valid options: Boolean. 
+#   Default: 'false'.
 #
 # @param target_group
 #   Sets the client's target group. Valid values: a string. Default: undef.
-#   This enabled parameter is only respected when the WSUS server allows clients to modify this setting via the TargetGroup and TargetGroupEnabled registry keys.
+#   This enabled parameter is only respected when the WSUS server allows clients to modify this setting via the TargetGroup and
+#   TargetGroupEnabled registry keys.
 #
 class wsus_client (
-  $server_url                                   = undef,
-  $enable_status_server                         = undef,
-  $accept_trusted_publisher_certs               = undef,
-  $auto_update_option                           = undef, #2..5 valid values
-  $auto_install_minor_updates                   = undef,
-  $detection_frequency_hours                    = undef,
-  $disable_windows_update_access                = undef,
-  $elevate_non_admins                           = undef,
-  $no_auto_reboot_with_logged_on_users          = undef,
-  $no_auto_update                               = undef,
-  $reboot_relaunch_timeout_minutes              = undef,
-  $reboot_warning_timeout_minutes               = undef,
-  $reschedule_wait_time_minutes                 = undef,
-  $scheduled_install_day                        = undef,
-  $scheduled_install_hour                       = undef,
-  $always_auto_reboot_at_scheduled_time         = undef,
-  $always_auto_reboot_at_scheduled_time_minutes = undef,
-  $target_group                                 = undef,
-  $purge_values                                 = false,
-){
+  Optional[Variant[Stdlib::HTTPUrl,Boolean]] $server_url                                                            = undef,
+  Optional[Boolean] $enable_status_server                                                                           = undef,
+  Optional[Boolean] $accept_trusted_publisher_certs                                                                 = undef,
+  Optional[Variant[Enum['NotifyOnly', 'AutoNotify', 'Scheduled', 'AutoInstall'],Integer[2,5]]] $auto_update_option  = undef,
+  Optional[Boolean] $auto_install_minor_updates                                                                     = undef,
+  Optional[Integer[1,22]] $detection_frequency_hours                                                                = undef,
+  Optional[Boolean] $disable_windows_update_access                                                                  = undef,
+  Optional[Boolean] $elevate_non_admins                                                                             = undef,
+  Optional[Boolean] $no_auto_reboot_with_logged_on_users                                                            = undef,
+  Optional[Boolean] $no_auto_update                                                                                 = undef,
+  Optional[Integer[1,1440]] $reboot_relaunch_timeout_minutes                                                        = undef,
+  Optional[Integer[1,30]] $reboot_warning_timeout_minutes                                                           = undef,
+  Optional[Integer[1,60]] $reschedule_wait_time_minutes                                                             = undef,
+  Optional[Variant[Enum['Everyday', 'Sunday', 'Monday', 'Tuesday', 'Wednesday','Thursday', 'Friday', 'Saturday'],Integer[0,7]]]
+  $scheduled_install_day                                                                                            = undef,
+  Optional[Integer[0,23]] $scheduled_install_hour                                                                   = undef,
+  Optional[Boolean] $always_auto_reboot_at_scheduled_time                                                           = undef,
+  Optional[Integer[15,180]] $always_auto_reboot_at_scheduled_time_minutes                                           = undef,
+  Boolean $purge_values                                                                                             = false,
+  Optional[String] $target_group                                                                                    = undef,
+) {
+  $_basekey = 'HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate'
 
-  $_basekey = $::operatingsystemrelease ? {
-    default => 'HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate'
-  }
-
-  $_au_base = $::operatingsystemrelease ? {
-    default => "${_basekey}\\AU"
-  }
+  $_au_base = "${_basekey}\\AU"
 
   validate_bool($purge_values)
 
-  registry_key{ $_basekey:
+  registry_key { $_basekey:
     ensure       => present,
-    purge_values => $purge_values
+    purge_values => $purge_values,
   }
 
-  registry_key{ $_au_base:
+  registry_key { $_au_base:
     ensure       => present,
-    purge_values => $purge_values
+    purge_values => $purge_values,
   }
 
-  service{ 'wuauserv':
+  service { 'wuauserv':
     enable => true,
   }
 
-  Registry_value{ require => Registry_key[$_basekey], notify => Service['wuauserv'] }
-
+  Registry_value { require => Registry_key[$_basekey], notify => Service['wuauserv'] }
 
   if ($server_url == undef or $server_url == false) and $enable_status_server {
     fail('server_url is required when specifying enable_status_server => true')
   }
 
   if $server_url  != undef {
-    wsus_client::setting{ "${_au_base}\\UseWUServer":
+    wsus_client::setting { "${_au_base}\\UseWUServer":
       data        => bool2num($server_url != false),
       has_enabled => false,
     }
     if $server_url {
       validate_re($server_url, '^http(|s):\/\/', "server_url is required to be either http or https, ${server_url}")
-      wsus_client::setting{ "${_basekey}\\WUServer":
+      wsus_client::setting { "${_basekey}\\WUServer":
         type        => 'string',
         data        => $server_url,
         has_enabled => false,
@@ -175,7 +202,7 @@ class wsus_client (
           true => 'present',
           false => 'absent',
         }
-        wsus_client::setting{ "${_basekey}\\WUStatusServer":
+        wsus_client::setting { "${_basekey}\\WUStatusServer":
           ensure      => $_ensure_status_server,
           type        => 'string',
           data        => $server_url,
@@ -185,13 +212,12 @@ class wsus_client (
     }
   }
 
-
   if $auto_update_option {
     $_parsed_auto_update_option = parse_auto_update_option($auto_update_option)
     if $_parsed_auto_update_option == 4 and !($scheduled_install_day and $scheduled_install_hour) {
       fail("scheduled_install_day and scheduled_install_hour required when specifying auto_update_option => '${auto_update_option}'")
     }
-    wsus_client::setting{ "${_au_base}\\AUOptions":
+    wsus_client::setting { "${_au_base}\\AUOptions":
       data        => $_parsed_auto_update_option,
       has_enabled => false,
     }
@@ -199,7 +225,7 @@ class wsus_client (
 
   wsus_client::setting { "${_basekey}\\AcceptTrustedPublisherCerts":
     data          => $accept_trusted_publisher_certs,
-    has_enabled   =>  false,
+    has_enabled   => false,
     validate_bool => true,
   }
 
@@ -209,46 +235,46 @@ class wsus_client (
     validate_bool => true,
   }
 
-  wsus_client::setting{ "${_au_base}\\DetectionFrequency":
+  wsus_client::setting { "${_au_base}\\DetectionFrequency":
     data           => $detection_frequency_hours,
     validate_range => [1,22],
   }
 
-  wsus_client::setting{ "${_basekey}\\DisableWindowsUpdateAccess":
+  wsus_client::setting { "${_basekey}\\DisableWindowsUpdateAccess":
     data          => $disable_windows_update_access,
     has_enabled   => false,
     validate_bool => true,
   }
 
-  wsus_client::setting{ "${_basekey}\\ElevateNonAdmins":
+  wsus_client::setting { "${_basekey}\\ElevateNonAdmins":
     data          => $elevate_non_admins,
     has_enabled   => false,
     validate_bool => true,
   }
 
-  wsus_client::setting{ "${_au_base}\\NoAutoRebootWithLoggedOnUsers":
+  wsus_client::setting { "${_au_base}\\NoAutoRebootWithLoggedOnUsers":
     data          => $no_auto_reboot_with_logged_on_users,
     has_enabled   => false,
     validate_bool => true,
   }
 
-  wsus_client::setting{ "${_au_base}\\NoAutoUpdate":
+  wsus_client::setting { "${_au_base}\\NoAutoUpdate":
     data          => $no_auto_update,
     has_enabled   => false,
     validate_bool => true,
   }
 
-  wsus_client::setting{ "${_au_base}\\RebootRelaunchTimeout":
+  wsus_client::setting { "${_au_base}\\RebootRelaunchTimeout":
     data           => $reboot_relaunch_timeout_minutes,
     validate_range => [1,1440],
   }
 
-  wsus_client::setting{ "${_au_base}\\RebootWarningTimeout":
+  wsus_client::setting { "${_au_base}\\RebootWarningTimeout":
     data           => $reboot_warning_timeout_minutes,
-    validate_range => [1,30]
+    validate_range => [1,30],
   }
 
-  wsus_client::setting{ "${_au_base}\\RescheduleWaitTime":
+  wsus_client::setting { "${_au_base}\\RescheduleWaitTime":
     data           => $reschedule_wait_time_minutes,
     validate_range => [1,60],
   }
@@ -260,29 +286,29 @@ class wsus_client (
     default  => $scheduled_install_day
   }
 
-  wsus_client::setting{ "${_au_base}\\ScheduledInstallDay":
+  wsus_client::setting { "${_au_base}\\ScheduledInstallDay":
     data           => $_scheduled_install_day,
     validate_range => [0,7],
     has_enabled    => false,
   }
 
-  wsus_client::setting{ "${_au_base}\\ScheduledInstallTime":
+  wsus_client::setting { "${_au_base}\\ScheduledInstallTime":
     data           => $scheduled_install_hour,
     validate_range => [0,23],
     has_enabled    => false,
   }
 
-  wsus_client::setting{ "${_basekey}\\TargetGroup":
+  wsus_client::setting { "${_basekey}\\TargetGroup":
     type => 'string',
     data => $target_group,
   }
 
-  wsus_client::setting{ "${_au_base}\\AlwaysAutoRebootAtScheduledTime":
+  wsus_client::setting { "${_au_base}\\AlwaysAutoRebootAtScheduledTime":
     data          => $always_auto_reboot_at_scheduled_time,
     has_enabled   => false,
     validate_bool => true,
   }
-  wsus_client::setting{ "${_au_base}\\AlwaysAutoRebootAtScheduledTimeMinutes":
+  wsus_client::setting { "${_au_base}\\AlwaysAutoRebootAtScheduledTimeMinutes":
     data           => $always_auto_reboot_at_scheduled_time_minutes,
     validate_range => [15,180],
     has_enabled    => false,

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -22,26 +22,25 @@
 # @param validate_bool
 #   Specifies whether the data should be validated as a boolean value
 #
-define wsus_client::setting(
-  $ensure = 'present',
-  $key = $title,
-  $data = undef,
-  $type = 'dword',
-  $has_enabled = true,
-  $validate_range = undef,
-  $validate_bool = false,
+define wsus_client::setting (
+  Enum['present', 'absent', 'file'] $ensure                         = 'present',
+  String $key                                                       = $title,
+  Optional[Variant[String,Integer,Boolean,Stdlib::HTTPUrl]] $data   = undef,
+  String $type                                                      = 'dword',
+  Boolean $has_enabled                                              = true,
+  Optional[Tuple[Integer, Integer]] $validate_range                 = undef,
+  Boolean $validate_bool                                            = false,
 
-)
-{
+) {
   assert_private()
   if $data != undef {
     if $has_enabled {
-      registry_value{ "${key}Enabled":
+      registry_value { "${key}Enabled":
         type => dword,
-        data => bool2num($data != false)
+        data => bool2num($data != false),
       }
     }
-    if ($data and $data != true) or $validate_bool{
+    if ($data and $data != true) or $validate_bool {
       if $validate_range {
         validate_in_range($data,$validate_range[0],$validate_range[1])
       }
@@ -52,7 +51,7 @@ define wsus_client::setting(
         true => bool2num($data),
         false => $data
       }
-      registry_value{ $key:
+      registry_value { $key:
         ensure => $ensure,
         type   => $type,
         data   => $_data,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,19 +51,19 @@ describe 'wsus_client' do
 
   shared_examples 'below range' do
     let(:params) { { param_sym => below_range } }
-    let(:error_message) { %r{Expected #{below_range} to be greater or equal to \d+, got #{below_range}} }
+    let(:error_message) { %r{expects a value of type Undef, Integer} }
 
     it {
-      expect { catalogue }.to raise_error(Puppet::Error, error_message)
+      expect { catalogue.to_s }.to raise_error(error_message)
     }
   end
 
   shared_examples 'above range' do
     let(:params) { { param_sym => above_range } }
-    let(:error_message) { %r{Expected #{above_range} to be less or equal to \d+, got #{above_range}} }
+    let(:error_message) { %r{expects a value of type Undef, Integer} }
 
     it {
-      expect { catalogue }.to raise_error(Puppet::Error, error_message)
+      expect { catalogue }.to raise_error(error_message)
     }
   end
 
@@ -234,7 +234,7 @@ describe 'wsus_client' do
                 auto_update_option: au_opt,
               }
             end
-            let(:error_message) { %r{Valid options for auto_update_option are 2|3|4|5, provided #{au_opt}} }
+            let(:error_message) { %r{expects a value of type Undef} }
 
             it_behaves_like 'fail validation'
           end
@@ -409,6 +409,7 @@ describe 'wsus_client' do
         let(:param_sym) { :always_auto_reboot_at_scheduled_time_minutes }
         let(:below_range) { 14 }
         let(:above_range) { 181 }
+        let(:range) { [15, 180] }
 
         it_behaves_like 'valid range', [15, 83, 180]
         it_behaves_like 'below range'


### PR DESCRIPTION
Previous to this commit, the wsus_client module would fail to start
unit and/or spec testing on any PR, crashing at the beginning of the
process and throwing syntax errors.

This commit aims to review and fix multiple syntax warnings, making sure
that the module complies with syntax standards and that each parameter
has an appropriate data type assigned.

Note: This is backwards incompatible.