### PR TITLE
(MAINT) Drop support for Windows 7, 8, 2008 (Server) and 2008 R2 (Server)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,11 +21,7 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "10",
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
- Support for Windows 7 and 8 was removed.
- Support for Windows Server 2008 and 2008 R2 was removed. ﻿

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html