### PR TITLE
(CONT-860) Update registry dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
+      "version_requirement": ">= 1.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Following the last major version update for puppetlabs-registry, several modules found themselves needing a dependency update. This commit aims to adjust the registry dependency within the module so that it is compatible with registry 5.0.0 and onwards.