### PR TITLE
pdksync - (CAT-1366) - Fix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-wsus_client",
   "project_page": "https://github.com/puppetlabs/puppetlabs-wsus_client",
-  "issues_url": "https://tickets.puppet.com/browse/MODULES/",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-wsus_client/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
(CAT-1366) - Fix issue url from old jira to github
pdk version: `3.0.0` 
