### PR TITLE
[MODULES-11611]: Added support for configuring Active Hours in WSUS client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,32 +84,6 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
-Performance/AncestorsInclude:
-  Enabled: true
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-Performance/CaseWhenSplat:
-  Enabled: true
-Performance/ConstantRegexp:
-  Enabled: true
-Performance/MethodObjectAsBlock:
-  Enabled: true
-Performance/RedundantSortBlock:
-  Enabled: true
-Performance/RedundantStringChars:
-  Enabled: true
-Performance/ReverseFirst:
-  Enabled: true
-Performance/SortReverse:
-  Enabled: true
-Performance/Squeeze:
-  Enabled: true
-Performance/StringInclude:
-  Enabled: true
-Performance/Sum:
-  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,16 @@
 #   Sets the timer to warning a signed-in user that a restart is going to occur. Valid values: integers 15 through 180. Default: undef.
 #    When the timer runs out, the restart will proceed even if the PC has signed-in users.
 #
+# @param active_hours_start
+#   Sets the start time for Active Hours in 24-hour format. Valid values: integers 0 through 23. Default: undef.
+#   Active Hours prevent automatic restarts during specified times. Both active_hours_start and active_hours_end must be set
+#   to enable this feature. When both are defined, the SetActiveHours registry key is automatically enabled.
+#
+# @param active_hours_end
+#   Sets the end time for Active Hours in 24-hour format. Valid values: integers 0 through 23. Default: undef.
+#   Active Hours prevent automatic restarts during specified times. Both active_hours_start and active_hours_end must be set
+#   to enable this feature. When both are defined, the SetActiveHours registry key is automatically enabled.
+#
 # @param purge_values
 #   Determines whether Puppet purges values of unmanaged registry keys under the WindowsUpdate parent key. Valid options: Boolean. 
 #   Default: 'false'.
@@ -157,6 +167,8 @@ class wsus_client (
   Optional[Variant[Integer[0,23],Boolean]] $scheduled_install_hour                                                  = undef,
   Optional[Boolean] $always_auto_reboot_at_scheduled_time                                                           = undef,
   Optional[Variant[Integer[15,180],Boolean]] $always_auto_reboot_at_scheduled_time_minutes                          = undef,
+  Optional[Variant[Integer[0,23],Boolean]] $active_hours_start                                                      = undef,
+  Optional[Variant[Integer[0,23],Boolean]] $active_hours_end                                                        = undef,
   Boolean $purge_values                                                                                             = false,
   Optional[Variant[String,Boolean]] $target_group                                                                   = undef,
 ) {
@@ -322,5 +334,30 @@ class wsus_client (
     data           => $always_auto_reboot_at_scheduled_time_minutes,
     validate_range => [15,180],
     has_enabled    => false,
+  }
+
+  # Active Hours configuration
+  if $active_hours_start != undef and $active_hours_end != undef {
+    $_enable_active_hours = ($active_hours_start != false and $active_hours_end != false)
+
+    wsus_client::setting { "${_basekey}\\SetActiveHours":
+      data          => $_enable_active_hours,
+      has_enabled   => false,
+      validate_bool => true,
+    }
+
+    if $_enable_active_hours {
+      wsus_client::setting { "${_basekey}\\ActiveHoursStart":
+        data           => $active_hours_start,
+        validate_range => [0,23],
+        has_enabled    => false,
+      }
+
+      wsus_client::setting { "${_basekey}\\ActiveHoursEnd":
+        data           => $active_hours_end,
+        validate_range => [0,23],
+        has_enabled    => false,
+      }
+    }
   }
 }

--- a/spec/acceptance/wsus_client_spec.rb
+++ b/spec/acceptance/wsus_client_spec.rb
@@ -314,4 +314,64 @@ RSpec.describe 'wsus_client' do
       end
     end
   end
+
+  context 'with active_hours_start and active_hours_end =>' do
+    describe 'enabled with valid hours' do
+      [{ start: 0, end: 23 }, { start: 8, end: 18 }, { start: 22, end: 6 }].each do |hours|
+        describe "start: #{hours[:start]}, end: #{hours[:end]}" do
+          it {
+            create_apply_manifest(
+              active_hours_start: hours[:start],
+              active_hours_end: hours[:end],
+            )
+          }
+
+          it_behaves_like 'registry_value', 'SetActiveHours' do
+            let(:reg_data) { 1 }
+          end
+          it_behaves_like 'registry_value', 'ActiveHoursStart' do
+            let(:reg_data) { hours[:start] }
+          end
+          it_behaves_like 'registry_value', 'ActiveHoursEnd' do
+            let(:reg_data) { hours[:end] }
+          end
+        end
+      end
+    end
+
+    describe 'disabled when set to false' do
+      it {
+        create_apply_manifest(
+          active_hours_start: false,
+          active_hours_end: false,
+        )
+      }
+
+      it_behaves_like 'registry_value', 'SetActiveHours' do
+        let(:reg_data) { 0 }
+      end
+      it_behaves_like 'registry_value undefined', 'ActiveHoursStart'
+      it_behaves_like 'registry_value undefined', 'ActiveHoursEnd'
+    end
+
+    describe 'not created when only start is set' do
+      it {
+        create_apply_manifest active_hours_start: 8
+      }
+
+      it_behaves_like 'registry_value undefined', 'SetActiveHours'
+      it_behaves_like 'registry_value undefined', 'ActiveHoursStart'
+      it_behaves_like 'registry_value undefined', 'ActiveHoursEnd'
+    end
+
+    describe 'not created when only end is set' do
+      it {
+        create_apply_manifest active_hours_end: 18
+      }
+
+      it_behaves_like 'registry_value undefined', 'SetActiveHours'
+      it_behaves_like 'registry_value undefined', 'ActiveHoursStart'
+      it_behaves_like 'registry_value undefined', 'ActiveHoursEnd'
+    end
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -430,6 +430,112 @@ describe 'wsus_client' do
         it_behaves_like 'above range'
         it_behaves_like 'non enabled feature'
       end
+
+      context 'with active_hours_start =>' do
+        let(:reg_key) { "#{base_key}\\ActiveHoursStart" }
+        let(:param_sym) { :active_hours_start }
+        let(:range) { [0, 23] }
+        let(:below_range) { range[0] - 1 }
+        let(:above_range) { range[1] + 1 }
+
+        [0, 12, 23].each do |hour|
+          describe hour.to_s do
+            let(:params) do
+              {
+                active_hours_start: hour,
+                active_hours_end: 18
+              }
+            end
+            let(:reg_data) { hour }
+
+            it_behaves_like 'registry_value'
+          end
+        end
+
+        it_behaves_like 'above range'
+        it_behaves_like 'non enabled feature', 8 do
+          let(:params) { { active_hours_start: 8, active_hours_end: 18 } }
+        end
+
+        describe 'not created when only start is set' do
+          let(:params) { { active_hours_start: 8 } }
+
+          it { is_expected.not_to contain_registry_value("#{base_key}\\SetActiveHours") }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursStart") }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursEnd") }
+        end
+
+        describe 'creates SetActiveHours when both start and end are set' do
+          let(:params) { { active_hours_start: 8, active_hours_end: 18 } }
+
+          it {
+            expect(subject).to contain_registry_value("#{base_key}\\SetActiveHours").with(
+              'type' => 'dword',
+              'data' => 1,
+            )
+          }
+          it {
+            expect(subject).to contain_registry_value("#{base_key}\\ActiveHoursStart").with(
+              'type' => 'dword',
+              'data' => 8,
+            )
+          }
+          it {
+            expect(subject).to contain_registry_value("#{base_key}\\ActiveHoursEnd").with(
+              'type' => 'dword',
+              'data' => 18,
+            )
+          }
+        end
+
+        describe 'disabled when both set to false' do
+          let(:params) { { active_hours_start: false, active_hours_end: false } }
+
+          it {
+            expect(subject).to contain_registry_value("#{base_key}\\SetActiveHours").with(
+              'type' => 'dword',
+              'data' => 0,
+            )
+          }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursStart") }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursEnd") }
+        end
+      end
+
+      context 'with active_hours_end =>' do
+        let(:reg_key) { "#{base_key}\\ActiveHoursEnd" }
+        let(:param_sym) { :active_hours_end }
+        let(:range) { [0, 23] }
+        let(:below_range) { range[0] - 1 }
+        let(:above_range) { range[1] + 1 }
+
+        [0, 12, 23].each do |hour|
+          describe hour.to_s do
+            let(:params) do
+              {
+                active_hours_start: 8,
+                active_hours_end: hour
+              }
+            end
+            let(:reg_data) { hour }
+
+            it_behaves_like 'registry_value'
+          end
+        end
+
+        it_behaves_like 'above range'
+        it_behaves_like 'non enabled feature', 18 do
+          let(:params) { { active_hours_start: 8, active_hours_end: 18 } }
+        end
+
+        describe 'not created when only end is set' do
+          let(:params) { { active_hours_end: 18 } }
+
+          it { is_expected.not_to contain_registry_value("#{base_key}\\SetActiveHours") }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursStart") }
+          it { is_expected.not_to contain_registry_value("#{base_key}\\ActiveHoursEnd") }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Added support for configuring Active Hours in WSUS client module

- Introduced parameters `active_hours_start` and `active_hours_end` to manage Active Hours.
- Updated the module's logic to enable/disable automatic restarts based on Active Hours settings.
- Added acceptance and unit tests to validate Active Hours functionality.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)