### PR TITLE
(MODULES-11708) Widen puppetlabs/registry dependency to allow 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 6.0.0"
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary

`puppetlabs-registry` is releasing v6.0.0 (https://github.com/puppetlabs/puppetlabs-registry/pull/321), part of the MODULES-11698 Puppet 9 support epic. This module's `metadata.json` capped the `puppetlabs/registry` dependency at `< 6.0.0`, which would block Forge dependency resolution for anyone consuming the new registry release alongside `puppetlabs-wsus_client`.

- `puppetlabs/registry` dependency: `>= 1.0.0 < 6.0.0` → `>= 1.0.0 < 7.0.0`

## Relation to Puppet 9 effort

This module (`puppetlabs-wsus_client`, MODULES-11737) has not yet released Puppet 9 support itself (still `puppet >= 8.0.0 < 9.0.0` on the Forge, ticket status Accepted) — that is tracked separately under MODULES-11737. This PR only unblocks the `registry` dependency chain per the MODULES-11698 dependency matrix; it does not add Puppet 9 support to this module.

Ticket: MODULES-11708

🤖 Generated with [Claude Code](https://claude.com/claude-code)